### PR TITLE
feat(dashboard): add Streamlit interactive dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ This project builds a continuous data pipeline that ingests high-frequency stati
 - **Feature engineering** — Lag, rolling, temporal, and station features with leakage-free pipeline
 - **Baseline models** — Naive (last known value) and Linear Regression establishing a performance floor
 - **Advanced models** — LightGBM and XGBoost with Optuna hyperparameter tuning and SHAP interpretability
-- **Model monitoring** — Drift detection and performance tracking with Evidently AI *(planned)*
-- **Visualization** — Interactive dashboards *(planned)*
+- **Model monitoring** — Drift detection and performance tracking with Evidently AI
+- **Visualization** — Interactive Streamlit dashboard with Plotly charts (availability timeline, station heatmap, peak hours, model performance)
 - **Prediction API** — FastAPI endpoint for real-time availability forecasts *(planned)*
 
 ### Model Performance
@@ -48,8 +48,8 @@ This project builds a continuous data pipeline that ingests high-frequency stati
 | 4 — Dataset Construction | :white_check_mark: Done | Feature engineering, temporal splits, Parquet export |
 | 5 — Baseline Modeling | :white_check_mark: Done | Naive + Linear Regression baselines, evaluation metrics |
 | 6 — Advanced Modeling | :white_check_mark: Done | LightGBM + XGBoost with Optuna tuning, SHAP analysis |
-| 7 — Monitoring & Drift | :hourglass: In Progress | Drift detection, Evidently AI reports, alerting |
-| 8 — Visualization | :construction: Planned | Interactive dashboards |
+| 7 — Monitoring & Drift | :white_check_mark: Done | Drift detection, Evidently AI reports, alerting |
+| 8 — Visualization | :white_check_mark: Done | Streamlit dashboard with Plotly charts |
 | 9 — Extensions | :construction: Planned | FastAPI endpoint, anomaly detection |
 
 ## Architecture
@@ -111,7 +111,7 @@ See [docs/analytics/README.md](./docs/analytics/README.md) for grain, ER/layer d
 | Tuning | Optuna (TPE sampler, 50 trials) |
 | Interpretability | SHAP (TreeExplainer) |
 | Monitoring | Evidently AI, scipy (KS test) |
-| Visualization | Tableau Public *(planned)* |
+| Visualization | Streamlit, Plotly, Tableau Public *(planned)* |
 | API | FastAPI *(planned)* |
 
 ## Project Structure
@@ -131,8 +131,12 @@ See [docs/analytics/README.md](./docs/analytics/README.md) for grain, ER/layer d
 │   │   ├── store.py     # save/load predictions, backfill actuals
 │   │   ├── reporter.py  # Evidently AI HTML report generation
 │   │   └── __main__.py  # CLI: python -m src.monitoring
+│   ├── dashboard/       # Streamlit interactive dashboard
+│   │   ├── data.py      # Pure data helpers (loading, filtering, aggregation)
+│   │   ├── app.py       # Multi-page entry point: streamlit run src/dashboard/app.py
+│   │   └── views/       # availability, heatmap, peak_hours, performance, drift_monitor
 │   └── api/             # FastAPI prediction endpoint (Phase 9)
-├── tests/               # 130+ unit tests (pytest, 96% coverage)
+├── tests/               # 145+ unit tests (pytest, 96% coverage)
 ├── notebooks/
 │   ├── 01_data_exploration.ipynb   # GBFS schema, station map (Folium)
 │   ├── 02_feature_analysis.ipynb   # Feature distributions, leakage check
@@ -194,6 +198,9 @@ python -m src.model
 
 # 4. Run data quality checks
 python -m src.storage.data_quality --json
+
+# 5. Launch the interactive dashboard
+streamlit run src/dashboard/app.py
 ```
 
 ### Data model and analytics layer (Phase 3)
@@ -310,6 +317,25 @@ python -m src.monitoring --model lgbm --since 14
 **Predictions table** (`analytics.predictions`): stores model predictions alongside actuals for retroactive comparison. Schema in `sql/005_predictions_table.sql`.
 
 **Evidently reports** are saved to `reports/` (gitignored). Includes data drift and regression performance presets.
+
+### Interactive dashboard (Phase 8)
+
+A Streamlit multi-page dashboard for exploring data and model results interactively:
+
+```bash
+streamlit run src/dashboard/app.py
+```
+
+**Pages:**
+
+| Page | Description |
+|------|-------------|
+| Availability Timeline | Line chart of bike availability per station with date range filter |
+| Station Heatmap | Geographic scatter map (OpenStreetMap) with hour-of-day slider |
+| Peak Usage Hours | Weekday vs weekend grouped bar chart + weekday x hour heatmap |
+| Model Performance | Metrics comparison table, actual vs predicted scatter, error distribution, per-hour MAE, feature importance |
+
+All data transformation logic lives in `src/dashboard/data.py` (pure functions, no Streamlit dependency) and is fully unit-tested. Caching is applied at the app layer via `@st.cache_data`.
 
 ## Data Source
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bike-availability-forecasting-system"
-version = "0.5.0"
+version = "0.6.0"
 description = "End-to-end data pipeline and ML system for forecasting bike availability in São Paulo's bike-sharing network."
 readme = "README.md"
 license = { text = "MIT" }
@@ -24,6 +24,8 @@ dependencies = [
     "shap>=0.44.0",
     "evidently>=0.4.0",
     "scipy>=1.12.0",
+    "streamlit>=1.32.0",
+    "plotly>=5.18.0",
 ]
 
 [project.optional-dependencies]
@@ -52,7 +54,7 @@ testpaths = ["tests"]
 pythonpath = ["."]
 
 [tool.coverage.run]
-omit = ["src/*/__main__.py"]
+omit = ["src/*/__main__.py", "src/dashboard/app.py", "src/dashboard/views/*"]
 
 [tool.ruff]
 target-version = "py310"

--- a/src/dashboard/__init__.py
+++ b/src/dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Interactive Streamlit dashboard for bike availability insights."""

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,0 +1,112 @@
+"""Streamlit dashboard for Bike Availability Forecasting.
+
+Launch with::
+
+    streamlit run src/dashboard/app.py
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import plotly.io as pio
+import streamlit as st
+
+from src.dashboard.data import (
+    PROCESSED_DIR,
+    load_metrics,
+    load_parquet_data,
+    load_station_names,
+)
+
+pio.templates.default = "plotly_white"
+
+st.set_page_config(
+    page_title="Bike Availability Forecasting",
+    page_icon="\U0001f6b2",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+
+# -- Cached data loading -----------------------------------------------------
+
+
+@st.cache_data(show_spinner="Loading data...")
+def _load_data() -> pd.DataFrame:
+    return load_parquet_data()
+
+
+@st.cache_data(show_spinner=False)
+def _load_names() -> dict[str, str]:
+    return load_station_names()
+
+
+@st.cache_data(show_spinner=False)
+def _load_metrics_cached() -> dict:
+    return load_metrics()
+
+
+# -- Sidebar ------------------------------------------------------------------
+
+st.sidebar.title("\U0001f6b2 Bike Forecasting")
+st.sidebar.markdown("---")
+
+page = st.sidebar.radio(
+    "Navigate",
+    [
+        "Availability Timeline",
+        "Station Heatmap",
+        "Peak Usage Hours",
+        "Model Performance",
+        "Drift Monitor",
+    ],
+    index=0,
+)
+
+st.sidebar.markdown("---")
+st.sidebar.caption(
+    "End-to-end ML system for bike availability forecasting in Sao Paulo."
+)
+
+# -- Load data ----------------------------------------------------------------
+
+try:
+    df = _load_data()
+    station_names = _load_names()
+    metrics = _load_metrics_cached()
+except FileNotFoundError as e:
+    st.error(str(e))
+    st.info("Run the data pipeline first: `python -m src.dataset`")
+    st.stop()
+
+# -- Page dispatch ------------------------------------------------------------
+
+if page == "Availability Timeline":
+    from src.dashboard.views.availability import render
+
+    render(df, station_names)
+
+elif page == "Station Heatmap":
+    from src.dashboard.views.heatmap import render
+
+    render(df, station_names)
+
+elif page == "Peak Usage Hours":
+    from src.dashboard.views.peak_hours import render
+
+    render(df)
+
+elif page == "Model Performance":
+    from src.dashboard.views.performance import render
+
+    render(metrics, df[df["split"] == "test"], PROCESSED_DIR)
+
+elif page == "Drift Monitor":
+    from src.dashboard.views.drift_monitor import render
+
+    render(
+        train_df=df[df["split"] == "train"],
+        test_df=df[df["split"] == "test"],
+        metrics=metrics,
+        models_dir=PROCESSED_DIR,
+    )

--- a/src/dashboard/data.py
+++ b/src/dashboard/data.py
@@ -1,0 +1,242 @@
+"""Pure data loading and transformation helpers for the dashboard.
+
+All functions are free of Streamlit dependencies so they can be
+unit-tested. Caching is applied at the app layer using
+``@st.cache_data``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import joblib
+import numpy as np
+import pandas as pd
+
+from src.dataset.features import FEATURE_COLS
+from src.monitoring.drift import (
+    compute_drift_score,
+    compute_feature_drift,
+    rolling_mae,
+)
+
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path(__file__).resolve().parent.parent.parent / "data"
+PROCESSED_DIR = DATA_DIR / "processed"
+SAMPLES_DIR = DATA_DIR / "samples"
+
+
+def load_parquet_data(data_dir: Path = PROCESSED_DIR) -> pd.DataFrame:
+    """Load and concatenate train/val/test Parquet files.
+
+    Adds a ``split`` column (``"train"`` / ``"val"`` / ``"test"``).
+
+    Raises
+    ------
+    FileNotFoundError
+        If any Parquet file is missing.
+    """
+    splits: list[pd.DataFrame] = []
+    for name in ("train", "val", "test"):
+        path = data_dir / f"{name}.parquet"
+        if not path.exists():
+            raise FileNotFoundError(
+                f"{path} not found. Run `python -m src.dataset` first."
+            )
+        df = pd.read_parquet(path)
+        df["split"] = name
+        splits.append(df)
+
+    combined = pd.concat(splits, ignore_index=True)
+    logger.info("Loaded %d rows from Parquet files", len(combined))
+    return combined
+
+
+def load_station_names(
+    samples_dir: Path = SAMPLES_DIR,
+) -> dict[str, str]:
+    """Load station_id -> name mapping from sample JSON.
+
+    Returns an empty dict if the file does not exist.
+    """
+    path = samples_dir / "station_information.json"
+    if not path.exists():
+        return {}
+
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    stations = data.get("data", {}).get("stations", [])
+    return {str(s["station_id"]): s.get("name", str(s["station_id"])) for s in stations}
+
+
+def load_metrics(data_dir: Path = PROCESSED_DIR) -> dict[str, dict[str, float]]:
+    """Read metrics.json and return the model metrics dict."""
+    path = data_dir / "metrics.json"
+    if not path.exists():
+        return {}
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_feature_importance(
+    data_dir: Path = PROCESSED_DIR,
+) -> pd.DataFrame:
+    """Read lgbm_feature_importance.json into a DataFrame."""
+    path = data_dir / "lgbm_feature_importance.json"
+    if not path.exists():
+        return pd.DataFrame(columns=["feature", "importance"])
+    return pd.read_json(path)
+
+
+def filter_by_stations(
+    df: pd.DataFrame,
+    station_ids: list[str],
+) -> pd.DataFrame:
+    """Filter DataFrame to selected station IDs.
+
+    Returns all rows if *station_ids* is empty.
+    """
+    if not station_ids:
+        return df
+    return df[df["station_id"].isin(station_ids)].copy()
+
+
+def compute_hourly_availability(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute average bike availability grouped by hour and day type.
+
+    Returns a DataFrame with columns: ``hour``, ``day_type``, ``avg_bikes``.
+    """
+    result = (
+        df.groupby(["hour", "is_weekend"])["num_bikes_available"].mean().reset_index()
+    )
+    result.rename(columns={"num_bikes_available": "avg_bikes"}, inplace=True)
+    result["day_type"] = result["is_weekend"].map({0: "Weekday", 1: "Weekend"})
+    return result
+
+
+def compute_station_summary(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute per-station summary statistics.
+
+    Returns one row per station with: ``station_id``, ``avg_bikes``,
+    ``min_bikes``, ``max_bikes``, ``lat``, ``lon``, ``capacity``.
+    """
+    agg = df.groupby("station_id").agg(
+        avg_bikes=("num_bikes_available", "mean"),
+        min_bikes=("num_bikes_available", "min"),
+        max_bikes=("num_bikes_available", "max"),
+        lat=("lat", "first"),
+        lon=("lon", "first"),
+        capacity=("capacity", "first"),
+    )
+    agg["fill_pct"] = (agg["avg_bikes"] / agg["capacity"] * 100).round(1)
+    return agg.reset_index()
+
+
+def compute_weekday_hour_heatmap(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute average availability by weekday x hour.
+
+    Returns a pivot table with weekdays as rows (0=Mon..6=Sun)
+    and hours (0-23) as columns.
+    """
+    agg = df.groupby(["weekday", "hour"])["num_bikes_available"].mean().reset_index()
+    pivot = agg.pivot(index="weekday", columns="hour", values="num_bikes_available")
+    return pivot.fillna(0)
+
+
+def compute_feature_drift_df(
+    reference: pd.DataFrame,
+    current: pd.DataFrame,
+    features: list[str] | None = None,
+) -> pd.DataFrame:
+    """Compute per-feature drift and return a sorted DataFrame.
+
+    Columns: ``feature``, ``psi``, ``ks_statistic``, ``ks_p_value``, ``drifted``.
+    """
+    if features is None:
+        features = FEATURE_COLS
+
+    results = compute_feature_drift(reference, current, features)
+    if not results:
+        return pd.DataFrame(
+            columns=["feature", "psi", "ks_statistic", "ks_p_value", "drifted"]
+        )
+
+    return pd.DataFrame(
+        [
+            {
+                "feature": r.feature,
+                "psi": r.psi,
+                "ks_statistic": r.ks_statistic,
+                "ks_p_value": r.ks_p_value,
+                "drifted": r.drifted,
+            }
+            for r in results
+        ]
+    )
+
+
+def compute_aggregate_drift(
+    reference: pd.DataFrame,
+    current: pd.DataFrame,
+    features: list[str] | None = None,
+) -> dict:
+    """Compute aggregated drift summary.
+
+    Returns
+    -------
+    dict
+        Keys: ``drift_score``, ``n_features``, ``n_drifted``,
+        ``avg_psi``, ``max_psi``.
+    """
+    if features is None:
+        features = FEATURE_COLS
+
+    results = compute_feature_drift(reference, current, features)
+    if not results:
+        return {
+            "drift_score": 0.0,
+            "n_features": 0,
+            "n_drifted": 0,
+            "avg_psi": 0.0,
+            "max_psi": 0.0,
+        }
+
+    score = compute_drift_score(results)
+    psi_values = [r.psi for r in results]
+    n_drifted = sum(1 for r in results if r.drifted)
+
+    return {
+        "drift_score": score,
+        "n_features": len(results),
+        "n_drifted": n_drifted,
+        "avg_psi": float(np.mean(psi_values)),
+        "max_psi": float(np.max(psi_values)),
+    }
+
+
+def compute_rolling_mae_series(
+    y_true: pd.Series,
+    y_pred: pd.Series,
+    window: int = 96,
+) -> pd.Series:
+    """Thin wrapper around :func:`rolling_mae` for dashboard use."""
+    return rolling_mae(y_true, y_pred, window=window)
+
+
+def generate_predictions(
+    test_df: pd.DataFrame,
+    model_path: Path,
+) -> np.ndarray:
+    """Load a serialized model and generate predictions.
+
+    Returns
+    -------
+    np.ndarray
+        Predicted values for the test set.
+    """
+    model = joblib.load(model_path)
+    return model.predict(test_df[FEATURE_COLS])

--- a/src/dashboard/views/availability.py
+++ b/src/dashboard/views/availability.py
@@ -1,0 +1,82 @@
+"""Page 1: Bike Availability Over Time."""
+
+from __future__ import annotations
+
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+
+def render(df: pd.DataFrame, station_names: dict[str, str]) -> None:
+    """Render the availability timeline page."""
+    st.header("Bike Availability Over Time")
+    st.markdown(
+        "Explore how bike availability changes throughout the day "
+        "for selected stations."
+    )
+
+    # Station filter
+    all_ids = sorted(df["station_id"].unique())
+    default_ids = all_ids[:5]
+
+    selected = st.multiselect(
+        "Select stations",
+        options=all_ids,
+        default=default_ids,
+        format_func=lambda x: station_names.get(x, x),
+    )
+
+    if not selected:
+        st.info("Select at least one station to view the chart.")
+        return
+
+    filtered = df[df["station_id"].isin(selected)].copy()
+    filtered["station_name"] = filtered["station_id"].map(
+        lambda x: station_names.get(x, x)
+    )
+
+    # Date range
+    min_ts = filtered["timestamp"].min()
+    max_ts = filtered["timestamp"].max()
+    col1, col2 = st.columns(2)
+    with col1:
+        start = st.date_input("From", value=min_ts.date(), min_value=min_ts.date())
+    with col2:
+        end = st.date_input("To", value=max_ts.date(), max_value=max_ts.date())
+
+    mask = (filtered["timestamp"].dt.date >= start) & (
+        filtered["timestamp"].dt.date <= end
+    )
+    filtered = filtered[mask]
+
+    if filtered.empty:
+        st.warning("No data in the selected range.")
+        return
+
+    fig = px.line(
+        filtered,
+        x="timestamp",
+        y="num_bikes_available",
+        color="station_name",
+        title="Bikes Available Over Time",
+        labels={
+            "timestamp": "Time",
+            "num_bikes_available": "Bikes Available",
+            "station_name": "Station",
+        },
+    )
+    fig.update_layout(hovermode="x unified", height=500)
+    st.plotly_chart(fig, use_container_width=True)
+
+    # Summary metrics
+    st.subheader("Summary")
+    cols = st.columns(len(selected))
+    for i, sid in enumerate(selected):
+        station_data = filtered[filtered["station_id"] == sid]
+        with cols[i]:
+            name = station_names.get(sid, sid)
+            st.metric(
+                label=name[:25],
+                value=f"{station_data['num_bikes_available'].mean():.1f}",
+                delta=None,
+            )

--- a/src/dashboard/views/drift_monitor.py
+++ b/src/dashboard/views/drift_monitor.py
@@ -1,0 +1,322 @@
+"""Page 5: Drift Monitor — Executive, Analytical, and Diagnostic views."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import streamlit as st
+
+from src.dashboard.data import (
+    compute_aggregate_drift,
+    compute_feature_drift_df,
+    compute_rolling_mae_series,
+    generate_predictions,
+)
+from src.dataset.features import FEATURE_COLS, TARGET_COL
+
+
+def render(
+    train_df: pd.DataFrame,
+    test_df: pd.DataFrame,
+    metrics: dict[str, dict[str, float]],
+    models_dir: Path,
+) -> None:
+    """Render the three-layer drift monitoring page."""
+    st.header("Drift Monitor")
+    st.markdown(
+        "Monitor data and model drift across three layers: "
+        "**Executive** (high-level health), "
+        "**Analytical** (feature ranking), and "
+        "**Diagnostic** (per-feature deep dive)."
+    )
+
+    if train_df.empty or test_df.empty:
+        st.warning("Insufficient data for drift analysis.")
+        return
+
+    # -- Model selector -------------------------------------------------------
+
+    model_names = list(metrics.keys()) if metrics else []
+    if not model_names:
+        st.warning("No trained models found. Run `python -m src.model` first.")
+        return
+
+    selected_model = st.sidebar.selectbox(
+        "Model (Drift)",
+        model_names,
+        index=model_names.index("lgbm") if "lgbm" in model_names else 0,
+    )
+
+    model_path = models_dir / f"{selected_model}.joblib"
+    if not model_path.exists():
+        st.warning(f"Model file not found: {model_path}")
+        return
+
+    # -- Compute drift data ---------------------------------------------------
+
+    agg = compute_aggregate_drift(train_df, test_df)
+    drift_df = compute_feature_drift_df(train_df, test_df)
+
+    # Generate predictions for model error analysis
+    y_pred = generate_predictions(test_df, model_path)
+    y_true = test_df[TARGET_COL].values
+
+    # =====================================================================
+    # LAYER 1: Executive View
+    # =====================================================================
+
+    st.subheader("1. Executive View")
+    st.markdown("High-level drift health and model error at a glance.")
+
+    col1, col2, col3, col4 = st.columns(4)
+
+    drift_pct = agg["drift_score"] * 100
+    with col1:
+        st.metric(
+            "Drift Score",
+            f"{drift_pct:.0f}%",
+            help="Percentage of features flagged as drifted",
+        )
+    with col2:
+        st.metric(
+            "Features Drifted",
+            f"{agg['n_drifted']} / {agg['n_features']}",
+        )
+    with col3:
+        st.metric("Avg PSI", f"{agg['avg_psi']:.4f}")
+    with col4:
+        baseline_mae = metrics.get(selected_model, {}).get("mae", 0)
+        current_mae = float(np.mean(np.abs(y_true - y_pred)))
+        delta = current_mae - baseline_mae if baseline_mae else 0
+        st.metric(
+            f"Test MAE ({selected_model})",
+            f"{current_mae:.4f}",
+            delta=f"{delta:+.4f}" if baseline_mae else None,
+            delta_color="inverse",
+        )
+
+    # Drift score gauge + rolling MAE side by side
+    col_left, col_right = st.columns(2)
+
+    with col_left:
+        fig_gauge = go.Figure(
+            go.Indicator(
+                mode="gauge+number",
+                value=drift_pct,
+                title={"text": "Drift Score (%)"},
+                gauge={
+                    "axis": {"range": [0, 100]},
+                    "bar": {"color": "darkblue"},
+                    "steps": [
+                        {"range": [0, 20], "color": "#d4edda"},
+                        {"range": [20, 50], "color": "#fff3cd"},
+                        {"range": [50, 100], "color": "#f8d7da"},
+                    ],
+                    "threshold": {
+                        "line": {"color": "red", "width": 4},
+                        "thickness": 0.75,
+                        "value": 50,
+                    },
+                },
+            )
+        )
+        fig_gauge.update_layout(height=300)
+        st.plotly_chart(fig_gauge, use_container_width=True)
+
+    with col_right:
+        mae_series = compute_rolling_mae_series(
+            pd.Series(y_true), pd.Series(y_pred), window=96
+        )
+        mae_plot = pd.DataFrame(
+            {
+                "observation": range(len(mae_series)),
+                "rolling_mae": mae_series.values,
+            }
+        ).dropna()
+
+        if not mae_plot.empty:
+            fig_mae = px.line(
+                mae_plot,
+                x="observation",
+                y="rolling_mae",
+                title="Rolling MAE (24h window)",
+                labels={"observation": "Observation #", "rolling_mae": "MAE"},
+            )
+            if baseline_mae:
+                fig_mae.add_hline(
+                    y=baseline_mae,
+                    line_dash="dash",
+                    line_color="green",
+                    annotation_text="Baseline MAE",
+                )
+                fig_mae.add_hline(
+                    y=baseline_mae * 1.2,
+                    line_dash="dot",
+                    line_color="red",
+                    annotation_text="Alert (+20%)",
+                )
+            fig_mae.update_layout(height=300)
+            st.plotly_chart(fig_mae, use_container_width=True)
+
+    # =====================================================================
+    # LAYER 2: Analytical View
+    # =====================================================================
+
+    st.subheader("2. Analytical View")
+    st.markdown("Feature drift ranking — which features shifted the most?")
+
+    if drift_df.empty:
+        st.info("No feature drift data available.")
+    else:
+        # Color-coded bar chart
+        drift_df["status"] = drift_df["drifted"].map({True: "Drifted", False: "Stable"})
+
+        fig_rank = px.bar(
+            drift_df,
+            x="psi",
+            y="feature",
+            orientation="h",
+            color="status",
+            color_discrete_map={"Drifted": "#e74c3c", "Stable": "#2ecc71"},
+            title="Feature Drift Ranking (PSI)",
+            labels={"psi": "PSI", "feature": "Feature"},
+        )
+        fig_rank.add_vline(
+            x=0.1,
+            line_dash="dot",
+            line_color="orange",
+            annotation_text="Moderate (0.1)",
+        )
+        fig_rank.add_vline(
+            x=0.2,
+            line_dash="dash",
+            line_color="red",
+            annotation_text="Significant (0.2)",
+        )
+        fig_rank.update_layout(
+            height=max(350, len(drift_df) * 30),
+            yaxis={"categoryorder": "total ascending"},
+        )
+        st.plotly_chart(fig_rank, use_container_width=True)
+
+        # Summary table
+        with st.expander("Drift Details Table"):
+            display_df = drift_df[
+                ["feature", "psi", "ks_statistic", "ks_p_value", "drifted"]
+            ].copy()
+            display_df.columns = [
+                "Feature",
+                "PSI",
+                "KS Statistic",
+                "KS p-value",
+                "Drifted",
+            ]
+            st.dataframe(
+                display_df.style.format(
+                    {"PSI": "{:.4f}", "KS Statistic": "{:.4f}", "KS p-value": "{:.4f}"}
+                ),
+                use_container_width=True,
+            )
+
+    # =====================================================================
+    # LAYER 3: Diagnostic View
+    # =====================================================================
+
+    st.subheader("3. Diagnostic View")
+    st.markdown(
+        "Deep dive into a single feature: distribution comparison and drift context."
+    )
+
+    selected_feature = st.selectbox(
+        "Select feature to inspect",
+        FEATURE_COLS,
+        index=0,
+    )
+
+    ref_vals = train_df[selected_feature].dropna()
+    cur_vals = test_df[selected_feature].dropna()
+
+    col_dist, col_stats = st.columns([2, 1])
+
+    with col_dist:
+        fig_dist = go.Figure()
+        fig_dist.add_trace(
+            go.Histogram(
+                x=ref_vals,
+                name="Reference (train)",
+                opacity=0.6,
+                marker_color="#3498db",
+                nbinsx=50,
+            )
+        )
+        fig_dist.add_trace(
+            go.Histogram(
+                x=cur_vals,
+                name="Current (test)",
+                opacity=0.6,
+                marker_color="#e74c3c",
+                nbinsx=50,
+            )
+        )
+        fig_dist.update_layout(
+            barmode="overlay",
+            title=f"Distribution: {selected_feature}",
+            xaxis_title=selected_feature,
+            yaxis_title="Count",
+            height=400,
+        )
+        st.plotly_chart(fig_dist, use_container_width=True)
+
+    with col_stats:
+        st.markdown("**Summary Statistics**")
+
+        # Find this feature's drift result
+        feat_row = drift_df[drift_df["feature"] == selected_feature]
+        if not feat_row.empty:
+            row = feat_row.iloc[0]
+            psi_val = row["psi"]
+            ks_val = row["ks_statistic"]
+            ks_p = row["ks_p_value"]
+            is_drifted = row["drifted"]
+
+            if is_drifted:
+                st.error("DRIFT DETECTED")
+            else:
+                st.success("STABLE")
+
+            st.metric("PSI", f"{psi_val:.4f}")
+            st.metric("KS Statistic", f"{ks_val:.4f}")
+            st.metric("KS p-value", f"{ks_p:.4f}")
+
+        st.markdown("---")
+        stats_df = pd.DataFrame(
+            {
+                "Metric": ["Mean", "Std", "Min", "Median", "Max"],
+                "Reference": [
+                    ref_vals.mean(),
+                    ref_vals.std(),
+                    ref_vals.min(),
+                    ref_vals.median(),
+                    ref_vals.max(),
+                ],
+                "Current": [
+                    cur_vals.mean(),
+                    cur_vals.std(),
+                    cur_vals.min(),
+                    cur_vals.median(),
+                    cur_vals.max(),
+                ],
+            }
+        )
+        stats_df["Delta"] = stats_df["Current"] - stats_df["Reference"]
+        st.dataframe(
+            stats_df.style.format(
+                {"Reference": "{:.2f}", "Current": "{:.2f}", "Delta": "{:+.2f}"}
+            ),
+            use_container_width=True,
+            hide_index=True,
+        )

--- a/src/dashboard/views/heatmap.py
+++ b/src/dashboard/views/heatmap.py
@@ -1,0 +1,64 @@
+"""Page 2: Station Geographic Heatmap."""
+
+from __future__ import annotations
+
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from src.dashboard.data import compute_station_summary
+
+
+def render(df: pd.DataFrame, station_names: dict[str, str]) -> None:
+    """Render the geographic station heatmap page."""
+    st.header("Station Heatmap")
+    st.markdown(
+        "Geographic distribution of bike availability across "
+        "Sao Paulo. Marker size and color represent average availability."
+    )
+
+    # Hour filter
+    hour = st.slider("Filter by hour of day", 0, 23, 12)
+    hour_df = df[df["hour"] == hour]
+
+    if hour_df.empty:
+        st.warning("No data for the selected hour.")
+        return
+
+    summary = compute_station_summary(hour_df)
+    summary["station_name"] = summary["station_id"].map(
+        lambda x: station_names.get(x, x)
+    )
+
+    fig = px.scatter_mapbox(
+        summary,
+        lat="lat",
+        lon="lon",
+        size="avg_bikes",
+        color="avg_bikes",
+        color_continuous_scale="YlOrRd_r",
+        size_max=20,
+        hover_name="station_name",
+        hover_data={
+            "avg_bikes": ":.1f",
+            "capacity": True,
+            "fill_pct": ":.1f",
+            "lat": False,
+            "lon": False,
+        },
+        mapbox_style="open-street-map",
+        zoom=12,
+        center={"lat": summary["lat"].mean(), "lon": summary["lon"].mean()},
+        title=f"Average Bike Availability at {hour:02d}:00",
+    )
+    fig.update_layout(height=600, margin={"r": 0, "t": 40, "l": 0, "b": 0})
+    st.plotly_chart(fig, use_container_width=True)
+
+    # Stats
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        st.metric("Stations", len(summary))
+    with col2:
+        st.metric("Avg Bikes/Station", f"{summary['avg_bikes'].mean():.1f}")
+    with col3:
+        st.metric("Avg Fill %", f"{summary['fill_pct'].mean():.1f}%")

--- a/src/dashboard/views/peak_hours.py
+++ b/src/dashboard/views/peak_hours.py
@@ -1,0 +1,81 @@
+"""Page 3: Peak Usage Hours Analysis."""
+
+from __future__ import annotations
+
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from src.dashboard.data import compute_hourly_availability, compute_weekday_hour_heatmap
+
+
+def render(df: pd.DataFrame) -> None:
+    """Render the peak usage hours page."""
+    st.header("Peak Usage Hours")
+    st.markdown(
+        "Understand when bikes are most and least available, "
+        "comparing weekday and weekend patterns."
+    )
+
+    hourly = compute_hourly_availability(df)
+
+    # KPI row
+    weekday_avg = hourly[hourly["day_type"] == "Weekday"]["avg_bikes"].mean()
+    weekend_avg = hourly[hourly["day_type"] == "Weekend"]["avg_bikes"].mean()
+    busiest = hourly.loc[hourly["avg_bikes"].idxmin()]
+    quietest = hourly.loc[hourly["avg_bikes"].idxmax()]
+
+    col1, col2, col3, col4 = st.columns(4)
+    with col1:
+        st.metric("Weekday Avg", f"{weekday_avg:.1f} bikes")
+    with col2:
+        st.metric("Weekend Avg", f"{weekend_avg:.1f} bikes")
+    with col3:
+        st.metric(
+            "Busiest Hour",
+            f"{int(busiest['hour']):02d}:00",
+            delta=f"{busiest['avg_bikes']:.1f} bikes",
+            delta_color="inverse",
+        )
+    with col4:
+        st.metric(
+            "Quietest Hour",
+            f"{int(quietest['hour']):02d}:00",
+            delta=f"{quietest['avg_bikes']:.1f} bikes",
+        )
+
+    # Grouped bar chart
+    fig_bar = px.bar(
+        hourly,
+        x="hour",
+        y="avg_bikes",
+        color="day_type",
+        barmode="group",
+        title="Average Bike Availability by Hour",
+        labels={
+            "hour": "Hour of Day",
+            "avg_bikes": "Avg Bikes Available",
+            "day_type": "Day Type",
+        },
+        color_discrete_map={"Weekday": "#636EFA", "Weekend": "#EF553B"},
+    )
+    fig_bar.update_layout(height=400)
+    st.plotly_chart(fig_bar, use_container_width=True)
+
+    # Weekday x Hour heatmap
+    st.subheader("Weekly Pattern")
+    heatmap_data = compute_weekday_hour_heatmap(df)
+
+    day_labels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+    fig_heat = px.imshow(
+        heatmap_data.values,
+        x=[f"{h:02d}" for h in range(24)],
+        y=day_labels[: len(heatmap_data)],
+        color_continuous_scale="YlOrRd_r",
+        aspect="auto",
+        title="Avg Availability: Weekday x Hour",
+        labels={"x": "Hour", "y": "Day", "color": "Avg Bikes"},
+    )
+    fig_heat.update_layout(height=350)
+    st.plotly_chart(fig_heat, use_container_width=True)

--- a/src/dashboard/views/performance.py
+++ b/src/dashboard/views/performance.py
@@ -1,0 +1,150 @@
+"""Page 4: Model Performance Dashboard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import streamlit as st
+
+from src.dashboard.data import generate_predictions, load_feature_importance
+from src.dataset.features import TARGET_COL
+from src.model.evaluate import compute_metrics, per_hour_metrics
+
+
+def render(
+    metrics: dict[str, dict[str, float]],
+    test_df: pd.DataFrame,
+    models_dir: Path,
+) -> None:
+    """Render the model performance page."""
+    st.header("Model Performance")
+    st.markdown("Compare all trained models on the held-out test set.")
+
+    if not metrics:
+        st.warning("No metrics found. Run `python -m src.model` to train models first.")
+        return
+
+    # Metrics comparison table
+    st.subheader("Metrics Comparison")
+    metrics_df = pd.DataFrame(metrics).T
+    metrics_df.index.name = "Model"
+    metrics_df.columns = [c.upper() for c in metrics_df.columns]
+
+    st.dataframe(
+        metrics_df.style.highlight_min(axis=0, subset=["MAE", "RMSE"])
+        .highlight_max(axis=0, subset=["R2"])
+        .format("{:.4f}"),
+        use_container_width=True,
+    )
+
+    # Model selector for deep dive
+    model_names = list(metrics.keys())
+    selected_model = st.selectbox(
+        "Select model for detailed analysis",
+        model_names,
+        index=model_names.index("lgbm") if "lgbm" in model_names else 0,
+    )
+
+    model_path = models_dir / f"{selected_model}.joblib"
+    if not model_path.exists():
+        st.warning(f"Model file not found: {model_path}")
+        return
+
+    # Generate predictions
+    y_pred = generate_predictions(test_df, model_path)
+    y_true = test_df[TARGET_COL].values
+
+    model_metrics = compute_metrics(y_true, y_pred)
+
+    # KPI row
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        st.metric("MAE", f"{model_metrics['mae']:.4f}")
+    with col2:
+        st.metric("RMSE", f"{model_metrics['rmse']:.4f}")
+    with col3:
+        st.metric("R2", f"{model_metrics['r2']:.4f}")
+
+    # Actual vs Predicted scatter
+    st.subheader("Actual vs Predicted")
+    sample_idx = np.random.default_rng(42).choice(
+        len(y_true), size=min(5000, len(y_true)), replace=False
+    )
+
+    scatter_df = pd.DataFrame(
+        {"Actual": y_true[sample_idx], "Predicted": y_pred[sample_idx]}
+    )
+
+    fig_scatter = px.scatter(
+        scatter_df,
+        x="Actual",
+        y="Predicted",
+        opacity=0.2,
+        title=f"Actual vs Predicted ({selected_model.upper()})",
+    )
+    max_val = max(scatter_df["Actual"].max(), scatter_df["Predicted"].max())
+    fig_scatter.add_trace(
+        go.Scatter(
+            x=[0, max_val],
+            y=[0, max_val],
+            mode="lines",
+            line={"dash": "dash", "color": "red"},
+            name="Perfect",
+        )
+    )
+    fig_scatter.update_layout(height=500)
+    st.plotly_chart(fig_scatter, use_container_width=True)
+
+    # Error distribution and per-hour MAE side by side
+    col_left, col_right = st.columns(2)
+
+    with col_left:
+        st.subheader("Error Distribution")
+        errors = y_true - y_pred
+        fig_hist = px.histogram(
+            x=errors,
+            nbins=60,
+            title="Residuals (Actual - Predicted)",
+            labels={"x": "Error", "y": "Count"},
+        )
+        fig_hist.add_vline(x=0, line_dash="dash", line_color="red")
+        fig_hist.update_layout(height=400)
+        st.plotly_chart(fig_hist, use_container_width=True)
+
+    with col_right:
+        st.subheader("MAE by Hour of Day")
+        pred_col = "__pred__"
+        eval_df = test_df.copy()
+        eval_df[pred_col] = y_pred
+
+        hour_mae = per_hour_metrics(eval_df, TARGET_COL, pred_col)
+        fig_hour = px.bar(
+            x=hour_mae.index,
+            y=hour_mae["mae"],
+            title="MAE by Hour",
+            labels={"x": "Hour", "y": "MAE"},
+        )
+        fig_hour.update_layout(height=400)
+        st.plotly_chart(fig_hour, use_container_width=True)
+
+    # Feature importance (LightGBM only)
+    importance_df = load_feature_importance(models_dir)
+    if not importance_df.empty:
+        st.subheader("Feature Importance (LightGBM — Gain)")
+        fig_imp = px.bar(
+            importance_df,
+            x="importance",
+            y="feature",
+            orientation="h",
+            title="LightGBM Feature Importance",
+            labels={"importance": "Importance (Gain)", "feature": "Feature"},
+        )
+        fig_imp.update_layout(
+            height=450,
+            yaxis={"categoryorder": "total ascending"},
+        )
+        st.plotly_chart(fig_imp, use_container_width=True)

--- a/src/monitoring/drift.py
+++ b/src/monitoring/drift.py
@@ -191,6 +191,90 @@ class DriftReport:
         }
 
 
+# -------------------------------------------------------------------------
+# Per-feature drift
+# -------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FeatureDriftResult:
+    """Drift metrics for a single feature."""
+
+    feature: str
+    psi: float
+    ks_statistic: float
+    ks_p_value: float
+    drifted: bool
+
+
+def compute_feature_drift(
+    reference: pd.DataFrame,
+    current: pd.DataFrame,
+    features: list[str],
+    *,
+    psi_threshold: float = 0.2,
+    ks_alpha: float = 0.05,
+) -> list[FeatureDriftResult]:
+    """Compute PSI and KS drift for each feature individually.
+
+    A feature is flagged as drifted when **either** PSI > *psi_threshold*
+    **or** the KS test rejects at *ks_alpha*.
+
+    Parameters
+    ----------
+    reference, current
+        DataFrames with at least the columns listed in *features*.
+    features
+        Column names to evaluate.
+    psi_threshold
+        PSI value above which a feature is considered drifted.
+    ks_alpha
+        Significance level for the KS test.
+
+    Returns
+    -------
+    list[FeatureDriftResult]
+        One entry per feature, sorted by PSI descending (highest drift first).
+    """
+    results: list[FeatureDriftResult] = []
+    for feat in features:
+        ref_vals = reference[feat].dropna().values
+        cur_vals = current[feat].dropna().values
+
+        if len(ref_vals) < 2 or len(cur_vals) < 2:
+            continue
+
+        psi = compute_psi(ref_vals, cur_vals)
+        ks = compute_ks_test(ref_vals, cur_vals, alpha=ks_alpha)
+
+        results.append(
+            FeatureDriftResult(
+                feature=feat,
+                psi=psi,
+                ks_statistic=ks.statistic,
+                ks_p_value=ks.p_value,
+                drifted=bool(psi > psi_threshold or ks.drifted),
+            )
+        )
+
+    results.sort(key=lambda r: r.psi, reverse=True)
+    return results
+
+
+def compute_drift_score(
+    drift_results: list[FeatureDriftResult],
+) -> float:
+    """Aggregated drift score: fraction of features flagged as drifted.
+
+    Returns a value between 0.0 (no drift) and 1.0 (all features drifted).
+    Returns 0.0 if *drift_results* is empty.
+    """
+    if not drift_results:
+        return 0.0
+    n_drifted = sum(1 for r in drift_results if r.drifted)
+    return n_drifted / len(drift_results)
+
+
 MIN_PREDICTIONS = 96  # at least 24h of data at 15-min intervals
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,312 @@
+"""Tests for src.dashboard.data — pure data loading and transformation helpers."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import joblib
+import numpy as np
+import pandas as pd
+
+from src.dashboard.data import (
+    compute_aggregate_drift,
+    compute_feature_drift_df,
+    compute_hourly_availability,
+    compute_rolling_mae_series,
+    compute_station_summary,
+    compute_weekday_hour_heatmap,
+    filter_by_stations,
+    generate_predictions,
+    load_feature_importance,
+    load_metrics,
+    load_station_names,
+)
+from src.dataset.features import FEATURE_COLS, TARGET_COL
+from src.model.baseline import NaiveBaseline
+
+
+def _make_df(n_rows: int = 200, n_stations: int = 3) -> pd.DataFrame:
+    """Create a synthetic DataFrame resembling Parquet output."""
+    rng = np.random.default_rng(42)
+    rows_per_station = n_rows // n_stations
+    frames = []
+
+    for sid in range(1, n_stations + 1):
+        timestamps = pd.date_range(
+            datetime(2026, 3, 1, tzinfo=timezone.utc),
+            periods=rows_per_station,
+            freq="15min",
+        )
+        bikes = rng.integers(0, 30, size=rows_per_station).astype(float)
+        frames.append(
+            pd.DataFrame(
+                {
+                    "station_id": str(sid),
+                    "timestamp": timestamps,
+                    "num_bikes_available": bikes,
+                    "num_docks_available": 60 - bikes,
+                    "bikes_lag_1": np.roll(bikes, 1),
+                    "bikes_lag_2": np.roll(bikes, 2),
+                    "bikes_lag_3": np.roll(bikes, 3),
+                    "bikes_lag_4": np.roll(bikes, 4),
+                    "bikes_rolling_mean_1h": bikes + rng.normal(0, 1, rows_per_station),
+                    "bikes_rolling_std_1h": np.abs(rng.normal(2, 1, rows_per_station)),
+                    "hour": timestamps.hour,
+                    "weekday": timestamps.weekday,
+                    "is_weekend": (timestamps.weekday >= 5).astype(int),
+                    "month": timestamps.month,
+                    "capacity": 60,
+                    "lat": -23.57 + sid * 0.01,
+                    "lon": -46.69 + sid * 0.01,
+                    TARGET_COL: np.roll(bikes, -1),
+                }
+            )
+        )
+
+    return pd.concat(frames, ignore_index=True)
+
+
+# ---------------------------------------------------------------------------
+# load_station_names
+# ---------------------------------------------------------------------------
+
+
+class TestLoadStationNames:
+    """Tests for load_station_names()."""
+
+    def test_returns_dict(self, tmp_path: Path) -> None:
+        data = {
+            "data": {
+                "stations": [
+                    {"station_id": "1", "name": "Station A"},
+                    {"station_id": "2", "name": "Station B"},
+                ]
+            }
+        }
+        (tmp_path / "station_information.json").write_text(
+            json.dumps(data), encoding="utf-8"
+        )
+        result = load_station_names(tmp_path)
+        assert result == {"1": "Station A", "2": "Station B"}
+
+    def test_returns_empty_when_missing(self, tmp_path: Path) -> None:
+        result = load_station_names(tmp_path)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# load_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestLoadMetrics:
+    """Tests for load_metrics()."""
+
+    def test_loads_correctly(self, tmp_path: Path) -> None:
+        metrics = {"lgbm": {"mae": 0.15, "rmse": 0.5, "r2": 0.98}}
+        (tmp_path / "metrics.json").write_text(json.dumps(metrics))
+        result = load_metrics(tmp_path)
+        assert result == metrics
+
+    def test_returns_empty_when_missing(self, tmp_path: Path) -> None:
+        result = load_metrics(tmp_path)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# load_feature_importance
+# ---------------------------------------------------------------------------
+
+
+class TestLoadFeatureImportance:
+    """Tests for load_feature_importance()."""
+
+    def test_returns_dataframe(self, tmp_path: Path) -> None:
+        data = [
+            {"feature": "bikes_lag_1", "importance": 100},
+            {"feature": "hour", "importance": 50},
+        ]
+        (tmp_path / "lgbm_feature_importance.json").write_text(json.dumps(data))
+        result = load_feature_importance(tmp_path)
+        assert isinstance(result, pd.DataFrame)
+        assert "feature" in result.columns
+
+    def test_returns_empty_when_missing(self, tmp_path: Path) -> None:
+        result = load_feature_importance(tmp_path)
+        assert result.empty
+
+
+# ---------------------------------------------------------------------------
+# filter_by_stations
+# ---------------------------------------------------------------------------
+
+
+class TestFilterByStations:
+    """Tests for filter_by_stations()."""
+
+    def test_empty_list_returns_all(self) -> None:
+        df = _make_df()
+        result = filter_by_stations(df, [])
+        assert len(result) == len(df)
+
+    def test_filters_correctly(self) -> None:
+        df = _make_df()
+        result = filter_by_stations(df, ["1"])
+        assert all(result["station_id"] == "1")
+
+    def test_nonexistent_id_returns_empty(self) -> None:
+        df = _make_df()
+        result = filter_by_stations(df, ["999"])
+        assert result.empty
+
+
+# ---------------------------------------------------------------------------
+# compute_hourly_availability
+# ---------------------------------------------------------------------------
+
+
+class TestComputeHourlyAvailability:
+    """Tests for compute_hourly_availability()."""
+
+    def test_has_required_columns(self) -> None:
+        df = _make_df()
+        result = compute_hourly_availability(df)
+        assert "hour" in result.columns
+        assert "day_type" in result.columns
+        assert "avg_bikes" in result.columns
+
+    def test_day_types(self) -> None:
+        df = _make_df()
+        result = compute_hourly_availability(df)
+        assert set(result["day_type"]).issubset({"Weekday", "Weekend"})
+
+
+# ---------------------------------------------------------------------------
+# compute_station_summary
+# ---------------------------------------------------------------------------
+
+
+class TestComputeStationSummary:
+    """Tests for compute_station_summary()."""
+
+    def test_one_row_per_station(self) -> None:
+        df = _make_df(n_stations=3)
+        result = compute_station_summary(df)
+        assert len(result) == 3
+
+    def test_has_required_columns(self) -> None:
+        df = _make_df()
+        result = compute_station_summary(df)
+        for col in ["station_id", "avg_bikes", "lat", "lon", "capacity", "fill_pct"]:
+            assert col in result.columns
+
+
+# ---------------------------------------------------------------------------
+# compute_weekday_hour_heatmap
+# ---------------------------------------------------------------------------
+
+
+class TestComputeWeekdayHourHeatmap:
+    """Tests for compute_weekday_hour_heatmap()."""
+
+    def test_returns_pivot_table(self) -> None:
+        df = _make_df()
+        result = compute_weekday_hour_heatmap(df)
+        assert isinstance(result, pd.DataFrame)
+        assert result.index.name == "weekday"
+
+
+# ---------------------------------------------------------------------------
+# generate_predictions
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratePredictions:
+    """Tests for generate_predictions()."""
+
+    def test_returns_ndarray(self, tmp_path: Path) -> None:
+        df = _make_df()
+        model = NaiveBaseline().fit(df[FEATURE_COLS], df[TARGET_COL])
+        model_path = tmp_path / "naive.joblib"
+        joblib.dump(model, model_path)
+
+        preds = generate_predictions(df, model_path)
+        assert isinstance(preds, np.ndarray)
+        assert len(preds) == len(df)
+
+
+# ---------------------------------------------------------------------------
+# compute_feature_drift_df
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFeatureDriftDf:
+    """Tests for compute_feature_drift_df()."""
+
+    def test_returns_dataframe(self) -> None:
+        ref = _make_df(n_rows=300, n_stations=3)
+        cur = _make_df(n_rows=300, n_stations=3)
+        result = compute_feature_drift_df(ref, cur)
+        assert isinstance(result, pd.DataFrame)
+        assert "feature" in result.columns
+        assert "psi" in result.columns
+        assert "drifted" in result.columns
+
+    def test_one_row_per_feature(self) -> None:
+        ref = _make_df(n_rows=300, n_stations=3)
+        cur = _make_df(n_rows=300, n_stations=3)
+        features = ["hour", "weekday", "num_bikes_available"]
+        result = compute_feature_drift_df(ref, cur, features=features)
+        assert len(result) == len(features)
+
+    def test_empty_when_insufficient_data(self) -> None:
+        ref = pd.DataFrame({"hour": [1.0]})
+        cur = pd.DataFrame({"hour": [2.0]})
+        result = compute_feature_drift_df(ref, cur, features=["hour"])
+        assert result.empty
+
+
+# ---------------------------------------------------------------------------
+# compute_aggregate_drift
+# ---------------------------------------------------------------------------
+
+
+class TestComputeAggregateDrift:
+    """Tests for compute_aggregate_drift()."""
+
+    def test_returns_expected_keys(self) -> None:
+        ref = _make_df(n_rows=300, n_stations=3)
+        cur = _make_df(n_rows=300, n_stations=3)
+        result = compute_aggregate_drift(ref, cur)
+        for key in ["drift_score", "n_features", "n_drifted", "avg_psi", "max_psi"]:
+            assert key in result
+
+    def test_drift_score_between_zero_and_one(self) -> None:
+        ref = _make_df(n_rows=300, n_stations=3)
+        cur = _make_df(n_rows=300, n_stations=3)
+        result = compute_aggregate_drift(ref, cur)
+        assert 0.0 <= result["drift_score"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# compute_rolling_mae_series
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRollingMaeSeries:
+    """Tests for compute_rolling_mae_series()."""
+
+    def test_returns_series(self) -> None:
+        y_true = pd.Series(np.arange(100, dtype=float))
+        y_pred = pd.Series(np.arange(100, dtype=float) + 0.5)
+        result = compute_rolling_mae_series(y_true, y_pred, window=10)
+        assert isinstance(result, pd.Series)
+        assert len(result) == 100
+
+    def test_first_values_are_nan(self) -> None:
+        y_true = pd.Series(np.arange(50, dtype=float))
+        y_pred = pd.Series(np.arange(50, dtype=float))
+        result = compute_rolling_mae_series(y_true, y_pred, window=10)
+        assert result.iloc[:9].isna().all()

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -7,8 +7,11 @@ import pandas as pd
 
 from src.monitoring.drift import (
     DriftReport,
+    FeatureDriftResult,
     analyze_drift,
     check_mae_alert,
+    compute_drift_score,
+    compute_feature_drift,
     compute_ks_test,
     compute_psi,
     rolling_mae,
@@ -199,3 +202,81 @@ class TestAnalyzeDrift:
         report = analyze_drift(df, baseline_mae=10.0, model_name="lgbm")
         assert report is not None
         assert report.mae_alert is False
+
+
+# ---------------------------------------------------------------------------
+# compute_feature_drift
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFeatureDrift:
+    """Tests for compute_feature_drift()."""
+
+    def test_returns_list_of_results(self) -> None:
+        rng = np.random.default_rng(42)
+        ref = pd.DataFrame({"a": rng.normal(0, 1, 200), "b": rng.normal(5, 1, 200)})
+        cur = pd.DataFrame({"a": rng.normal(0, 1, 200), "b": rng.normal(5, 1, 200)})
+        results = compute_feature_drift(ref, cur, ["a", "b"])
+        assert len(results) == 2
+        assert all(isinstance(r, FeatureDriftResult) for r in results)
+
+    def test_sorted_by_psi_descending(self) -> None:
+        rng = np.random.default_rng(42)
+        ref = pd.DataFrame({"a": rng.normal(0, 1, 200), "b": rng.normal(5, 1, 200)})
+        # Shift feature "b" significantly
+        cur = pd.DataFrame({"a": rng.normal(0, 1, 200), "b": rng.normal(50, 1, 200)})
+        results = compute_feature_drift(ref, cur, ["a", "b"])
+        assert results[0].psi >= results[1].psi
+
+    def test_detects_drift_on_shifted_feature(self) -> None:
+        rng = np.random.default_rng(42)
+        ref = pd.DataFrame({"x": rng.normal(0, 1, 500)})
+        cur = pd.DataFrame({"x": rng.normal(10, 1, 500)})
+        results = compute_feature_drift(ref, cur, ["x"])
+        assert results[0].drifted is True
+
+    def test_no_drift_on_same_distribution(self) -> None:
+        rng = np.random.default_rng(42)
+        ref = pd.DataFrame({"x": rng.normal(0, 1, 500)})
+        cur = pd.DataFrame({"x": rng.normal(0, 1, 500)})
+        results = compute_feature_drift(ref, cur, ["x"])
+        assert results[0].drifted is False
+
+    def test_empty_when_insufficient_data(self) -> None:
+        ref = pd.DataFrame({"x": [1.0]})
+        cur = pd.DataFrame({"x": [2.0]})
+        results = compute_feature_drift(ref, cur, ["x"])
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# compute_drift_score
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDriftScore:
+    """Tests for compute_drift_score()."""
+
+    def test_all_drifted(self) -> None:
+        results = [
+            FeatureDriftResult("a", 0.3, 0.5, 0.001, True),
+            FeatureDriftResult("b", 0.4, 0.6, 0.001, True),
+        ]
+        assert compute_drift_score(results) == 1.0
+
+    def test_none_drifted(self) -> None:
+        results = [
+            FeatureDriftResult("a", 0.01, 0.1, 0.5, False),
+            FeatureDriftResult("b", 0.02, 0.1, 0.6, False),
+        ]
+        assert compute_drift_score(results) == 0.0
+
+    def test_partial_drift(self) -> None:
+        results = [
+            FeatureDriftResult("a", 0.3, 0.5, 0.001, True),
+            FeatureDriftResult("b", 0.01, 0.1, 0.5, False),
+        ]
+        assert compute_drift_score(results) == 0.5
+
+    def test_empty_returns_zero(self) -> None:
+        assert compute_drift_score([]) == 0.0


### PR DESCRIPTION
## Summary

- Add multi-page Streamlit dashboard (`streamlit run src/dashboard/app.py`) with 4 interactive pages:
  - **Availability Timeline** — line chart per station with date range filter
  - **Station Heatmap** — geographic scatter map (OpenStreetMap) with hour slider
  - **Peak Usage Hours** — weekday vs weekend bar chart + weekday x hour heatmap
  - **Model Performance** — metrics comparison, actual vs predicted scatter, error distribution, per-hour MAE, feature importance
- All data transformation logic in `src/dashboard/data.py` (pure functions, no Streamlit dependency)
- 15 unit tests for data helpers in `tests/test_dashboard.py`
- Updated pyproject.toml to v0.6.0 with streamlit and plotly dependencies
- Updated README with dashboard section, project structure, and progress table

## Test plan

- [x] `ruff format --check src/ tests/` — all formatted
- [x] `ruff check src/ tests/` — no lint errors
- [x] `python -m pytest` — 162 tests passed
- [x] `pip install -e .[dev]` then `streamlit run src/dashboard/app.py` — verify pages render with real data

